### PR TITLE
fix: remove unknown flag in Temporal CLI command, update Temporal SDK version

### DIFF
--- a/.bash.cfg
+++ b/.bash.cfg
@@ -14,5 +14,5 @@ alias ex1="cd ${GITPOD_REPO_ROOT}/exercises/version-workflow/practice"
 alias ex1s="cd ${GITPOD_REPO_ROOT}/exercises/version-workflow/solution"
 alias ex1w="mvn clean compile exec:java -Dexec.mainClass='getversion.LoanProcessingWorker'"
 alias ex1st="mvn clean compile exec:java -Dexec.mainClass='getversion.Starter' -Dexec.args='a100'"
-alias ex1h="temporal workflow show --workflow-id=loan-processing-workflow-customer-a100 --fields long  --output json > history_for_original_execution.json"
+alias ex1h="temporal workflow show --workflow-id=loan-processing-workflow-customer-a100 --output json > history_for_original_execution.json"
 

--- a/exercises/version-workflow/README.md
+++ b/exercises/version-workflow/README.md
@@ -49,7 +49,6 @@ the code.
    ```bash
    temporal workflow show \
       --workflow-id loan-processing-workflow-customer-a100 \
-      --fields long  \
       --output json > history_for_original_execution.json
    ```
    - You an also use the `ex1h` command within the GitPod environment to save yourself some typing.

--- a/exercises/version-workflow/practice/pom.xml
+++ b/exercises/version-workflow/practice/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>io.temporal</groupId>
             <artifactId>temporal-sdk</artifactId>
-            <version>1.20.1</version>
+            <version>1.24.2</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- Java Temporal SDK version
- Temporal CLI command

## Why?
As Temporal CLI on GitPod has version below, it doesn't recognize `--fields` option, which was mentioned in docs and `.bash.cfg`.
```shell
$ temporal --version
temporal version 1.0.0 (Server 1.24.2, UI 2.28.0)
```

Also, to replay with downloaded history file successfully in test code, Java Temporal SDK should be updated.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
By completing the course exercise.

3. Any docs updates needed?
https://docs.temporal.io/cli/workflow#show
